### PR TITLE
Fix docs, billing form and add tests

### DIFF
--- a/apps/next-store-template/README-zh-cn.md
+++ b/apps/next-store-template/README-zh-cn.md
@@ -141,7 +141,7 @@ Your Next Store 支持简单的变体产品。要创建带变体的产品，你�
 
 Your Next Store 使用 Stripe 网络钩子处理来自 Stripe 的事件。目前，该端点用于自动重新验证购物车页面和创建税务交易（如果启用）。要设置网络钩子，请参考 Stripe 文档。具体步骤取决于你是否在 Stripe 账户中激活了 Stripe 工作台：[docs.stripe.com/webhooks#add-a-webhook-endpoint](https://docs.stripe.com/webhooks#add-a-webhook-endpoint).
 
-网络钩子的端点是 `https://{YOUR_DOMAIN}/api/stripe-webhook`。唯一必需的事件是 `payment_intent.successed`。在 Stripe 中配置网络钩子后，将 `STRIPE_WEBHOOK_SECRET` 变量值设置为 Stripe 创建的密钥 (secret key)。
+网络钩子的端点是 `https://{YOUR_DOMAIN}/api/stripe-webhook`。唯一必需的事件是 `payment_intent.succeeded`。在 Stripe 中配置网络钩子后，将 `STRIPE_WEBHOOK_SECRET` 变量值设置为 Stripe 创建的密钥 (secret key)。
 
 > [!NOTE]备注
 > 我们之后计划为网络钩子中添加支持更多事件，以改善用户体验。

--- a/packages/next-auth/README.md
+++ b/packages/next-auth/README.md
@@ -1,1 +1,1 @@
-# `@hub/next-auth`
+# `@workspace/next-auth`

--- a/packages/ui/src/components/billing-form.tsx
+++ b/packages/ui/src/components/billing-form.tsx
@@ -36,7 +36,7 @@ export function BillingForm({
 
   function onSubmit(event: FormEvent<HTMLFormElement>): void {
     event.preventDefault();
-    setIsLoading(!isLoading);
+    setIsLoading(true);
 
     // Get a Stripe session URL.
     fetch('/api/users/stripe')
@@ -58,6 +58,9 @@ export function BillingForm({
       })
       .catch((error: Error) => {
         toast(error.message);
+      })
+      .finally(() => {
+        setIsLoading(false);
       });
   }
 

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
     "build": "echo 'Add build script here'",
     "dev": "echo 'Add dev script here'",
     "lint": "echo 'Add lint script here'",
-    "test": "echo 'Add test script here'"
+    "test": "vitest"
   },
   "version": "0.0.0"
 }

--- a/packages/utils/src/formatDate.test.ts
+++ b/packages/utils/src/formatDate.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { formatDate } from './formatDate';
+
+describe('formatDate', () => {
+  it('formats a date string to human readable', () => {
+    expect(formatDate('2024-01-02')).toBe('January 2, 2024');
+  });
+});


### PR DESCRIPTION
## Summary
- fix Stripe event name typo in Chinese README
- show proper loading state in BillingForm
- correct package heading for `@workspace/next-auth`
- add test for `formatDate` and expose test script

## Testing
- `pnpm --filter @workspace/utils test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cfe9904dc832186a7fab4fbb59dd7